### PR TITLE
Migrate to new Backstage frontend system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,95 @@
+# @vippsno/plugin-azure-resources
+
+A Backstage frontend plugin that adds an **Azure** tab to catalog entity pages, showing Azure resource groups, security recommendations, and cost advice — all scoped to the entity via an Azure tag.
+
+![backstage azure entity view](./docs/img/entity-view.png)
+
+## Features
+
+- **Resource groups** — lists Azure resource groups that match the entity's tag, with links to the Azure portal
+- **Security recommendations** — Microsoft Defender for Cloud recommendations, grouped by finding and sorted by severity
+- **Cost advisor** — Azure Advisor cost recommendations with estimated savings
+
+## Prerequisites
+
+Install and configure the [backstage-azure-resources-backend](https://github.com/ehrnst/backstage-azure-resources-backend) plugin first.
+
+## Installation
+
+This plugin targets the **Backstage new frontend system** (`createApp` from `@backstage/frontend-defaults`).
+
+### 1. Copy the plugin into your Backstage workspace
+
+The plugin must live inside your Backstage workspace to share a single React instance with the host app. Add the source under `plugins/azure-resources/` and register it as a workspace package:
+
+```json
+// backstage/plugins/azure-resources/package.json
+{
+  "name": "@vippsno/plugin-azure-resources",
+  "private": true,
+  "backstage": { "role": "frontend-plugin" },
+  "exports": {
+    ".": "./src/index.ts",
+    "./alpha": "./src/alpha.ts",
+    "./package.json": "./package.json"
+  }
+}
+```
+
+```json
+// packages/app/package.json
+{
+  "dependencies": {
+    "@vippsno/plugin-azure-resources": "workspace:*"
+  }
+}
+```
+
+### 2. Register the plugin in your app
+
+```ts
+// packages/app/src/App.tsx
+import azureResourcesAlpha from '@vippsno/plugin-azure-resources/alpha';
+
+const app = createApp({
+  features: [
+    // ... other plugins
+    azureResourcesAlpha,
+  ],
+});
+```
+
+### 3. Enable extension discovery
+
+```yaml
+# app-config.yaml
+app:
+  packages: all
+```
+
+That's it. The Azure tab appears automatically on any entity that has the `azure.com/tag-selector` annotation.
+
+## Annotation
+
+Add the following annotation to a catalog entity:
+
+```yaml
+metadata:
+  annotations:
+    azure.com/tag-selector: key/value
+```
+
+The plugin uses the tag key and value to query Azure Resource Graph for matching resources. For example:
+
+```yaml
+annotations:
+  azure.com/tag-selector: owner/team-platform
+```
+
+## Development
+
+```bash
+yarn install
+yarn lint
+yarn test
+```

--- a/package.json
+++ b/package.json
@@ -1,12 +1,12 @@
 {
   "name": "@vippsno/plugin-azure-resources",
-  "description": "A backstage plugin for showing Azure resoources",
+  "description": "A backstage plugin for showing Azure resources",
   "homepage": "https://github.com/vippsas/backstage-azure-resource-frontend",
   "bugs": {
     "url": "https://github.com/vippsas/backstage-azure-resource-frontend/issues"
   },
   "contributors": [],
-  "version": "1.0.8",
+  "version": "2.0.0",
   "main": "src/index.ts",
   "types": "src/index.ts",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,40 @@
   "types": "src/index.ts",
   "license": "MIT",
   "private": false,
+  "exports": {
+    ".": "./src/index.ts",
+    "./alpha": "./src/alpha.ts",
+    "./package.json": "./package.json"
+  },
+  "typesVersions": {
+    "*": {
+      "alpha": ["src/alpha.ts"],
+      "package.json": ["package.json"]
+    }
+  },
   "publishConfig": {
     "access": "public",
     "main": "dist/index.esm.js",
-    "types": "dist/index.d.ts"
+    "types": "dist/index.d.ts",
+    "exports": {
+      ".": {
+        "import": "./dist/index.esm.js",
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.esm.js"
+      },
+      "./alpha": {
+        "import": "./dist/alpha.esm.js",
+        "types": "./dist/alpha.d.ts",
+        "default": "./dist/alpha.esm.js"
+      },
+      "./package.json": "./package.json"
+    },
+    "typesVersions": {
+      "*": {
+        "alpha": ["dist/alpha.d.ts"],
+        "package.json": ["package.json"]
+      }
+    }
   },
   "backstage": {
     "role": "frontend-plugin"
@@ -29,18 +59,19 @@
     "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
-    "@backstage/core-components": "^0.11.0",
-    "@backstage/core-plugin-api": "^1.0.5",
-    "@backstage/theme": "^0.2.16",
-    "@material-ui/core": "^4.9.13",
-    "@material-ui/icons": "^4.9.1",
-    "@material-ui/lab": "4.0.0-alpha.57",
-    "express": "^4.18.1",
-    "express-promise-router": "^4.1.1",
     "react-use": "^17.2.4"
   },
   "peerDependencies": {
-    "react": "^16.13.1 || ^17.0.0"
+    "@backstage/catalog-model": "^1.7.6",
+    "@backstage/core-components": "^0.18.7",
+    "@backstage/core-plugin-api": "^1.12.3",
+    "@backstage/frontend-plugin-api": "^0.14.1",
+    "@backstage/plugin-catalog-react": "^2.0.0",
+    "@backstage/theme": "^0.7.2",
+    "@material-ui/core": "^4.12.4",
+    "@material-ui/icons": "^4.11.3",
+    "@material-ui/lab": "4.0.0-alpha.61",
+    "react": "^17.0.0 || ^18.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.18.1",

--- a/src/alpha.ts
+++ b/src/alpha.ts
@@ -1,0 +1,8 @@
+import { createFrontendPlugin } from '@backstage/frontend-plugin-api';
+import { entityAzureContent } from './extensions/entityCards';
+
+/** @alpha */
+export default createFrontendPlugin({
+  pluginId: 'azure-resources',
+  extensions: [entityAzureContent],
+});

--- a/src/components/EntityAzureContent/AzureEntityContent.tsx
+++ b/src/components/EntityAzureContent/AzureEntityContent.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Grid } from '@material-ui/core';
+import { GetEntityAzureResourceGroups } from '../EntityFetchAzureData/EntityFetchAzureData';
+import { GetEntityAzureSecurityRecommendations } from '../EntityFetchAzureData/EntityFetchAzureSecurityData';
+import { GetEntityAzureCostAdvice } from '../EntityFetchAzureData/EntityFetchAzureCostAdviceData';
+
+export const AzureEntityContent = () => (
+  <Grid container spacing={3}>
+    <Grid item xs={12}>
+      <GetEntityAzureResourceGroups />
+    </Grid>
+    <Grid item xs={12}>
+      <GetEntityAzureSecurityRecommendations />
+    </Grid>
+    <Grid item xs={12}>
+      <GetEntityAzureCostAdvice />
+    </Grid>
+  </Grid>
+);

--- a/src/components/EntityFetchAzureData/EntityFetchAzureCostAdviceData.tsx
+++ b/src/components/EntityFetchAzureData/EntityFetchAzureCostAdviceData.tsx
@@ -31,6 +31,9 @@ export const GetEntityAzureCostAdvice = () => {
     const backendUrl = config.getString('backend.baseUrl');
     const { value, loading, error } = useAsync(async (): Promise<CostAdvice[]> => {
         const response = await fetch(`${backendUrl}/api/azure-resources/rg/${tagKey}/${tagValue}/costadvice`);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch cost advice: ${response.status} ${response.statusText}`);
+        }
         const json = await response.json();
         return json.data;
     }, []);

--- a/src/components/EntityFetchAzureData/EntityFetchAzureData.tsx
+++ b/src/components/EntityFetchAzureData/EntityFetchAzureData.tsx
@@ -92,6 +92,9 @@ export const GetEntityAzureResourceGroups = () => {
   const backendUrl = config.getString('backend.baseUrl');
   const { value, loading, error } = useAsync(async (): Promise<EntityResourceGroups[]> => {
       const response = await fetch(`${backendUrl}/api/azure-resources/rg/${tagKey}/${tagValue}`);
+      if (!response.ok) {
+        throw new Error(`Failed to fetch resource groups: ${response.status} ${response.statusText}`);
+      }
       const json = await response.json();
       return json.data;
   }, []);

--- a/src/components/EntityFetchAzureData/EntityFetchAzureSecurityData.tsx
+++ b/src/components/EntityFetchAzureData/EntityFetchAzureSecurityData.tsx
@@ -35,6 +35,9 @@ export const GetEntityAzureSecurityRecommendations = () => {
     const backendUrl = config.getString('backend.baseUrl');
     const { value, loading, error } = useAsync(async (): Promise<SecurityRec[]> => {
         const response = await fetch(`${backendUrl}/api/azure-resources/rg/${tagKey}/${tagValue}/secrecommendations`);
+        if (!response.ok) {
+          throw new Error(`Failed to fetch security recommendations: ${response.status} ${response.statusText}`);
+        }
         const json = await response.json();
         return json.data;
     }, []);

--- a/src/extensions/entityCards.tsx
+++ b/src/extensions/entityCards.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { EntityContentBlueprint } from '@backstage/plugin-catalog-react/alpha';
+import { isAzureResourceEnabled } from '../components/entityData';
+
+/** @alpha */
+export const entityAzureContent = EntityContentBlueprint.make({
+  name: 'azure',
+  params: {
+    path: '/azure',
+    title: 'Azure',
+    filter: isAzureResourceEnabled,
+    loader: () =>
+      import('../components/EntityAzureContent/AzureEntityContent').then(m => (
+        <m.AzureEntityContent />
+      )),
+  },
+});


### PR DESCRIPTION
## Summary

- Adds `src/alpha.ts` entry point with `createFrontendPlugin` using the new Backstage frontend plugin API
- Replaces three separate `EntityCardBlueprint` extensions with a single `EntityContentBlueprint` tab (`/azure` path) via `src/extensions/entityCards.tsx`
- Adds `src/components/EntityAzureContent/AzureEntityContent.tsx` — composite component rendering resource groups, security recommendations, and cost advice in a grid
- Adds HTTP error handling (`response.ok` checks) to all three fetch components so failed requests surface as proper error messages instead of silent JSON parse failures
- Updates `package.json`: adds `/alpha` subpath exports + `typesVersions`, updates `publishConfig` with dist exports, moves core Backstage/MUI deps to `peerDependencies` with current versions

## Test plan

- [ ] Build the package (`yarn build`) and verify `dist/alpha.esm.js` is emitted
- [ ] Install in a Backstage app using the new frontend system and confirm the "Azure" tab appears on entities with the `azure.com/tag-selector` annotation
- [ ] Verify resource groups, security recommendations, and cost advice all load correctly in the tab
- [ ] Confirm HTTP errors (e.g. backend unavailable) show a readable error message instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)